### PR TITLE
add php-imagick dependencies

### DIFF
--- a/php7.1-imagick.json
+++ b/php7.1-imagick.json
@@ -4,13 +4,29 @@
   "license": "http://www.php.net/license/3_01.txt",
   "architecture": {
     "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x64.zip",
-      "hash": "35ee1bba25f2901affa24a22e60abcaae466327fd7f2c00e32ddeeec1a5910a4"
+      "url": [
+        "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x64.zip",
+        "http://windows.php.net/downloads/pecl/deps/ImageMagick-6.9.3-7-vc14-x64.zip"
+      ],
+      "hash": [
+        "35ee1bba25f2901affa24a22e60abcaae466327fd7f2c00e32ddeeec1a5910a4",
+        "25f115a5aec336d3039add9b0819d459787763ce86e0dd4804ac1bddee431f10"
+      ]
     },
     "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x86.zip",
-      "hash": "306e12c77dd9bf71b198f252d6c52914aa055a13d7a22e76567e9e4bd56373f6"
+      "url": [
+        "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x86.zip",
+        "http://windows.php.net/downloads/pecl/deps/ImageMagick-6.9.3-7-vc14-x86.zip"
+      ],
+      "hash": [
+        "306e12c77dd9bf71b198f252d6c52914aa055a13d7a22e76567e9e4bd56373f6",
+        "8d46ee896c2d13a4829dcfff5a8da9ac6bdd55c4da4d039ac726a0e211f46a16"
+      ]
     }
+  },
+  "env_add_path": "bin",
+  "env_set": {
+    "MAGICK_HOME": "$dir/bin"
   },
   "checkver": "imagick/([\\d.]+)/windows",
   "autoupdate": {

--- a/php7.1-imagick.json
+++ b/php7.1-imagick.json
@@ -25,9 +25,6 @@
     }
   },
   "env_add_path": "bin",
-  "env_set": {
-    "MAGICK_HOME": "$dir/bin"
-  },
   "checkver": "imagick/([\\d.]+)/windows",
   "autoupdate": {
     "architecture": {
@@ -39,7 +36,12 @@
       }
     }
   },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+  "post_install": "
+    iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)
+
+    Write-Host \"Remove .exe files to prevent confusion with imagemagick\"
+    Remove-Item $dir\\bin\\*.exe
+  ",
   "uninstaller": {
     "file": "uninstall.ps1"
   }


### PR DESCRIPTION
_Please wait with merging_

## Problem
I tracked down the error I get from the `php-imagick` extension

```
$ php -i
PHP Warning:  PHP Startup: Unable to load dynamic library 'C:\Benutzer\remy\scoop\apps\php7.1-imagick\current\php_imagick.dll' - Das angegebene Modul wurde nicht gefunden.
 in Unknown on line 0
// ...
```

It is because imagick depends on the correct imagemagick installation.
Hint, the `imagemagick` package from scoop core does not work ;-)

## Solution
The correct version has to be grabbed from http://windows.php.net/downloads/pecl/deps/
Unpacked somewhere and the `bin` directory has to be added to the `PATH` and a new environment variable `MAGICK_HOME`.
Then `php-imagick` loads correctly.

## Problem
Adding the imagemagick dependency to the $PATH overwrites the core imagemagick installation if present and could lead to problems if it is installed …

@r15ch13 do you have an idea how to solve this?