### PR TITLE
update extensions, hash fixes, formatting fixes

### DIFF
--- a/php7.1-apcu.json
+++ b/php7.1-apcu.json
@@ -12,7 +12,7 @@
             "hash": "924414c7d75fc3bb501abb7181a27ff394bb948a3e3ec7e7034a89ed4b995a80"
         }
     },
-    "checkver": "apcu/([\\d.]+)/windows",
+    "checkver": "(?i)apcu/([\\d.]+)/windows",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/php7.1-apcu.json
+++ b/php7.1-apcu.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/apcu",
-  "version": "5.1.8",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/apcu/5.1.8/php_apcu-5.1.8-7.1-ts-vc14-x64.zip",
-      "hash": "1158d0ff103c420f5772b1a6ab2c7b5a75b63b1b80eb926d92f19ca818fa87be"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/apcu/5.1.8/php_apcu-5.1.8-7.1-ts-vc14-x86.zip",
-      "hash": "924414c7d75fc3bb501abb7181a27ff394bb948a3e3ec7e7034a89ed4b995a80"
-    }
-  },
-  "checkver": "apcu/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/apcu",
+    "version": "5.1.8",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/apcu/$version/php_apcu-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/apcu/$version/php_apcu-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/apcu/5.1.8/php_apcu-5.1.8-7.1-ts-vc14-x64.zip",
+            "hash": "1158d0ff103c420f5772b1a6ab2c7b5a75b63b1b80eb926d92f19ca818fa87be"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/apcu/5.1.8/php_apcu-5.1.8-7.1-ts-vc14-x86.zip",
+            "hash": "924414c7d75fc3bb501abb7181a27ff394bb948a3e3ec7e7034a89ed4b995a80"
+        }
+    },
+    "checkver": "apcu/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/apcu/$version/php_apcu-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/apcu/$version/php_apcu-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-apcu_bc.json
+++ b/php7.1-apcu_bc.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/apcu_bc",
-  "version": "1.0.3",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/1.0.3/php_apcu_bc-1.0.3-7.1-ts-vc14-x64.zip",
-      "hash": "134d6f5cdaf4f923e2d4d45bcb235d6d5cfb8c0e984a630d83c415c657c3f5a0"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/1.0.3/php_apcu_bc-1.0.3-7.1-ts-vc14-x86.zip",
-      "hash": "c29ea19cfb207b728a41a2dfeb5d14fd94712f10c95415521c4e4cc065b904b6"
-    }
-  },
-  "checkver": "apcu_bc/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/apcu_bc",
+    "version": "1.0.3",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/$version/php_apcu_bc-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/$version/php_apcu_bc-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/1.0.3/php_apcu_bc-1.0.3-7.1-ts-vc14-x64.zip",
+            "hash": "134d6f5cdaf4f923e2d4d45bcb235d6d5cfb8c0e984a630d83c415c657c3f5a0"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/1.0.3/php_apcu_bc-1.0.3-7.1-ts-vc14-x86.zip",
+            "hash": "c29ea19cfb207b728a41a2dfeb5d14fd94712f10c95415521c4e4cc065b904b6"
+        }
+    },
+    "checkver": "apcu_bc/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/$version/php_apcu_bc-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/apcu_bc/$version/php_apcu_bc-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-bitset.json
+++ b/php7.1-bitset.json
@@ -12,7 +12,7 @@
             "hash": "542edc356a1a36e147a42899e242504705f1402f6cc58083d7adf8330d8b7240"
         }
     },
-    "checkver": "bitset/([\\d.]+)/windows",
+    "checkver": "(?i)bitset/([\\d.]+)/windows",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/php7.1-bitset.json
+++ b/php7.1-bitset.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/bitset",
-  "version": "3.0.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/bitset/3.0.0/php_bitset-3.0.0-7.1-ts-vc14-x64.zip",
-      "hash": "1492719390daca5d132d68e1b9d57ce5bd0a4ff7a829c09f08a623dc94c05153"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/bitset/3.0.0/php_bitset-3.0.0-7.1-ts-vc14-x86.zip",
-      "hash": "542edc356a1a36e147a42899e242504705f1402f6cc58083d7adf8330d8b7240"
-    }
-  },
-  "checkver": "bitset/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/bitset",
+    "version": "3.0.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/bitset/$version/php_bitset-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/bitset/$version/php_bitset-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/bitset/3.0.0/php_bitset-3.0.0-7.1-ts-vc14-x64.zip",
+            "hash": "1492719390daca5d132d68e1b9d57ce5bd0a4ff7a829c09f08a623dc94c05153"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/bitset/3.0.0/php_bitset-3.0.0-7.1-ts-vc14-x86.zip",
+            "hash": "542edc356a1a36e147a42899e242504705f1402f6cc58083d7adf8330d8b7240"
+        }
+    },
+    "checkver": "bitset/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/bitset/$version/php_bitset-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/bitset/$version/php_bitset-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-couchbase.json
+++ b/php7.1-couchbase.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://pecl.php.net/package/couchbase",
-    "version": "2.3.4",
+    "version": "2.4.0",
     "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/couchbase/2.3.4/php_couchbase-2.3.4-7.1-ts-vc14-x64.zip",
-            "hash": "072d6b8c20016bea701fd807b43d4e29d6494f7784fdd4c98a7664547a02e83e"
+            "url": "http://windows.php.net/downloads/pecl/releases/couchbase/2.4.0/php_couchbase-2.4.0-7.1-ts-vc14-x64.zip",
+            "hash": "f40dc13262f6be0110e5f04ee6665d6162906be7b31bdbd2bac85b4e8d2b82be"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/couchbase/2.3.4/php_couchbase-2.3.4-7.1-ts-vc14-x86.zip",
-            "hash": "82617fc5a80b44f4255c632075ab14b897694227d91a650552a65bb1ca28e43d"
+            "url": "http://windows.php.net/downloads/pecl/releases/couchbase/2.4.0/php_couchbase-2.4.0-7.1-ts-vc14-x86.zip",
+            "hash": "07a89a10be38989f1302046c27642c8d930c80b8f622f7d0440f560b271096d3"
         }
     },
     "checkver": "couchbase/([\\d.]+)/windows",

--- a/php7.1-crypto.json
+++ b/php7.1-crypto.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/crypto",
-  "version": "0.3.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/crypto/0.3.1/php_crypto-0.3.1-7.1-ts-vc14-x64.zip",
-      "hash": "33795465d16fb8bf9373daf6b625b55a5e4ff86b5543d6ae5c3d7bd99c0f3eee"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/crypto/0.3.1/php_crypto-0.3.1-7.1-ts-vc14-x86.zip",
-      "hash": "3ba4c7bf41f65ea8ac2ded92088efb6e3fedf0421f368dbcde7afbac07c31272"
-    }
-  },
-  "checkver": "crypto/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/crypto",
+    "version": "0.3.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/crypto/$version/php_crypto-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/crypto/$version/php_crypto-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/crypto/0.3.1/php_crypto-0.3.1-7.1-ts-vc14-x64.zip",
+            "hash": "33795465d16fb8bf9373daf6b625b55a5e4ff86b5543d6ae5c3d7bd99c0f3eee"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/crypto/0.3.1/php_crypto-0.3.1-7.1-ts-vc14-x86.zip",
+            "hash": "3ba4c7bf41f65ea8ac2ded92088efb6e3fedf0421f368dbcde7afbac07c31272"
+        }
+    },
+    "checkver": "crypto/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/crypto/$version/php_crypto-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/crypto/$version/php_crypto-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-dio.json
+++ b/php7.1-dio.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/dio",
-  "version": "0.1.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/dio/0.1.0/php_dio-0.1.0-7.1-ts-vc14-x64.zip",
-      "hash": "914b0c7c28c409d59153e3a54e35b2a284dcce558e58b0566909011734920810"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/dio/0.1.0/php_dio-0.1.0-7.1-ts-vc14-x86.zip",
-      "hash": "d3e654f0fadea70e19091169f9af3b6eb7f2e78aded2bcb5241791f30fa9f640"
-    }
-  },
-  "checkver": "dio/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/dio",
+    "version": "0.1.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/dio/$version/php_dio-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/dio/$version/php_dio-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/dio/0.1.0/php_dio-0.1.0-7.1-ts-vc14-x64.zip",
+            "hash": "914b0c7c28c409d59153e3a54e35b2a284dcce558e58b0566909011734920810"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/dio/0.1.0/php_dio-0.1.0-7.1-ts-vc14-x86.zip",
+            "hash": "d3e654f0fadea70e19091169f9af3b6eb7f2e78aded2bcb5241791f30fa9f640"
+        }
+    },
+    "checkver": "dio/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/dio/$version/php_dio-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/dio/$version/php_dio-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-doublemetaphone.json
+++ b/php7.1-doublemetaphone.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/doublemetaphone",
-  "version": "1.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/1.0.1/php_doublemetaphone-1.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "e7fa65276eea9486d3f229f911463066b96dfbc41e9c5811f29ef155f3a4b89c"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/1.0.1/php_doublemetaphone-1.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "a1c4337746a810a7df3addff433ed1ca6ffad3f2a13bcd504de961099af970dc"
-    }
-  },
-  "checkver": "doublemetaphone/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/doublemetaphone",
+    "version": "1.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/$version/php_doublemetaphone-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/$version/php_doublemetaphone-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/1.0.1/php_doublemetaphone-1.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "e7fa65276eea9486d3f229f911463066b96dfbc41e9c5811f29ef155f3a4b89c"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/1.0.1/php_doublemetaphone-1.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "a1c4337746a810a7df3addff433ed1ca6ffad3f2a13bcd504de961099af970dc"
+        }
+    },
+    "checkver": "doublemetaphone/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/$version/php_doublemetaphone-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/doublemetaphone/$version/php_doublemetaphone-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-event.json
+++ b/php7.1-event.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/event",
-  "version": "2.3.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/event/2.3.0/php_event-2.3.0-7.1-ts-vc14-x64.zip",
-      "hash": "83e327d58a4cd185320d008b43bdfce8473e27f51322593149a9061f63bfb4d6"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/event/2.3.0/php_event-2.3.0-7.1-ts-vc14-x86.zip",
-      "hash": "d656750f3899cd4200b8c3859679b6d5f0e271d0fead1f69a1f6dcfe25357296"
-    }
-  },
-  "checkver": "event/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/event",
+    "version": "2.3.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/event/$version/php_event-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/event/$version/php_event-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/event/2.3.0/php_event-2.3.0-7.1-ts-vc14-x64.zip",
+            "hash": "83e327d58a4cd185320d008b43bdfce8473e27f51322593149a9061f63bfb4d6"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/event/2.3.0/php_event-2.3.0-7.1-ts-vc14-x86.zip",
+            "hash": "d656750f3899cd4200b8c3859679b6d5f0e271d0fead1f69a1f6dcfe25357296"
+        }
+    },
+    "checkver": "event/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/event/$version/php_event-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/event/$version/php_event-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-fann.json
+++ b/php7.1-fann.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/fann",
-  "version": "1.1.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/fann/1.1.1/php_fann-1.1.1-7.1-ts-vc14-x64.zip",
-      "hash": "8080f399b090bd78be956aff4bec3aa19ad384cfdd3ed56ee05b67062012a780"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/fann/1.1.1/php_fann-1.1.1-7.1-ts-vc14-x86.zip",
-      "hash": "776f22df3cb3535130eaa290bd22481c96d73aad3cd70d9130a128d622b58d98"
-    }
-  },
-  "checkver": "fann/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/fann",
+    "version": "1.1.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/fann/$version/php_fann-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/fann/$version/php_fann-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/fann/1.1.1/php_fann-1.1.1-7.1-ts-vc14-x64.zip",
+            "hash": "8080f399b090bd78be956aff4bec3aa19ad384cfdd3ed56ee05b67062012a780"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/fann/1.1.1/php_fann-1.1.1-7.1-ts-vc14-x86.zip",
+            "hash": "776f22df3cb3535130eaa290bd22481c96d73aad3cd70d9130a128d622b58d98"
+        }
+    },
+    "checkver": "fann/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/fann/$version/php_fann-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/fann/$version/php_fann-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-gender.json
+++ b/php7.1-gender.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/gender",
-  "version": "1.1.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/gender/1.1.0/php_gender-1.1.0-7.1-ts-vc14-x64.zip",
-      "hash": "6ca1f57fe7a708acc88c79af6a6e961ffb37cbca9ecbcd24edcfcd77d459d32e"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/gender/1.1.0/php_gender-1.1.0-7.1-ts-vc14-x86.zip",
-      "hash": "ce5cac478a468b51d3c2ccb6c19bf16229a7468fd026428df15665f3aa233414"
-    }
-  },
-  "checkver": "gender/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/gender",
+    "version": "1.1.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/gender/$version/php_gender-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/gender/$version/php_gender-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/gender/1.1.0/php_gender-1.1.0-7.1-ts-vc14-x64.zip",
+            "hash": "6ca1f57fe7a708acc88c79af6a6e961ffb37cbca9ecbcd24edcfcd77d459d32e"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/gender/1.1.0/php_gender-1.1.0-7.1-ts-vc14-x86.zip",
+            "hash": "ce5cac478a468b51d3c2ccb6c19bf16229a7468fd026428df15665f3aa233414"
+        }
+    },
+    "checkver": "gender/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/gender/$version/php_gender-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/gender/$version/php_gender-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-geoip.json
+++ b/php7.1-geoip.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/geoip",
-  "version": "1.1.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/geoip/1.1.1/php_geoip-1.1.1-7.1-ts-vc14-x64.zip",
-      "hash": "8f630af800170310a46663cd0c5441841e1b2d866912e3b4354cbb42114d39e8"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/geoip/1.1.1/php_geoip-1.1.1-7.1-ts-vc14-x86.zip",
-      "hash": "adf4daace14c4a097bcd72536db5df35a3d4136b6fa38dab2404ee9d8b1bddd9"
-    }
-  },
-  "checkver": "geoip/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/geoip",
+    "version": "1.1.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/geoip/$version/php_geoip-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/geoip/$version/php_geoip-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/geoip/1.1.1/php_geoip-1.1.1-7.1-ts-vc14-x64.zip",
+            "hash": "8f630af800170310a46663cd0c5441841e1b2d866912e3b4354cbb42114d39e8"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/geoip/1.1.1/php_geoip-1.1.1-7.1-ts-vc14-x86.zip",
+            "hash": "adf4daace14c4a097bcd72536db5df35a3d4136b6fa38dab2404ee9d8b1bddd9"
+        }
+    },
+    "checkver": "geoip/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/geoip/$version/php_geoip-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/geoip/$version/php_geoip-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-hprose.json
+++ b/php7.1-hprose.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/hprose",
-  "version": "1.6.6",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/hprose/1.6.6/php_hprose-1.6.6-7.1-ts-vc14-x64.zip",
-      "hash": "d3f5588efcd54e9e52d383715090b6fde205483b202029862195f6b073c0d278"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/hprose/1.6.6/php_hprose-1.6.6-7.1-ts-vc14-x86.zip",
-      "hash": "0fae158c308c92789a238209f0231d2dde292814513f6deb1fc90a41580e277c"
-    }
-  },
-  "checkver": "hprose/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/hprose",
+    "version": "1.6.6",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/hprose/$version/php_hprose-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/hprose/$version/php_hprose-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/hprose/1.6.6/php_hprose-1.6.6-7.1-ts-vc14-x64.zip",
+            "hash": "d3f5588efcd54e9e52d383715090b6fde205483b202029862195f6b073c0d278"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/hprose/1.6.6/php_hprose-1.6.6-7.1-ts-vc14-x86.zip",
+            "hash": "0fae158c308c92789a238209f0231d2dde292814513f6deb1fc90a41580e277c"
+        }
+    },
+    "checkver": "hprose/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/hprose/$version/php_hprose-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/hprose/$version/php_hprose-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-igbinary.json
+++ b/php7.1-igbinary.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/igbinary",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/igbinary/2.0.1/php_igbinary-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "bf783b61b587b9bb8f5d3687e2f79398f784b6d5fe12d8b7ca70a7a3cfd97665"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/igbinary/2.0.1/php_igbinary-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "eeaac8bb5389def6080db70747281c781ad88e2d3f5d6b3a4d8bca6c8b80a5a8"
-    }
-  },
-  "checkver": "igbinary/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/igbinary",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/igbinary/$version/php_igbinary-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/igbinary/$version/php_igbinary-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/igbinary/2.0.1/php_igbinary-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "bf783b61b587b9bb8f5d3687e2f79398f784b6d5fe12d8b7ca70a7a3cfd97665"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/igbinary/2.0.1/php_igbinary-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "eeaac8bb5389def6080db70747281c781ad88e2d3f5d6b3a4d8bca6c8b80a5a8"
+        }
+    },
+    "checkver": "igbinary/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/igbinary/$version/php_igbinary-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/igbinary/$version/php_igbinary-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-imagick.json
+++ b/php7.1-imagick.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/imagick",
-  "version": "3.4.3",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x64.zip",
-      "hash": "35ee1bba25f2901affa24a22e60abcaae466327fd7f2c00e32ddeeec1a5910a4"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x86.zip",
-      "hash": "306e12c77dd9bf71b198f252d6c52914aa055a13d7a22e76567e9e4bd56373f6"
-    }
-  },
-  "checkver": "imagick/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/imagick",
+    "version": "3.4.3",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/imagick/$version/php_imagick-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/imagick/$version/php_imagick-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x64.zip",
+            "hash": "35ee1bba25f2901affa24a22e60abcaae466327fd7f2c00e32ddeeec1a5910a4"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/imagick/3.4.3/php_imagick-3.4.3-7.1-ts-vc14-x86.zip",
+            "hash": "306e12c77dd9bf71b198f252d6c52914aa055a13d7a22e76567e9e4bd56373f6"
+        }
+    },
+    "checkver": "imagick/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/imagick/$version/php_imagick-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/imagick/$version/php_imagick-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-mailparse.json
+++ b/php7.1-mailparse.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x64.zip",
-            "hash": "143266d822863006e807ca4602f95b8cbb39d63e0fe80c30a180c62f0cf69f32"
+            "hash": "1b74308181167a5ae0795824e4ef8fd77c09a81662caaebba3779dea86f328e9"
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x86.zip",
-            "hash": "011ec947bd9d8597f9e76084e7dca206f0461c0c1956781387ed34bc440d2988"
+            "hash": "c17e83ee3cfc81530c5796c4308cb0e5d5353bd887a5277c493f55cab89a5c19"
         }
     },
     "checkver": "mailparse/([\\d.]+)/windows",

--- a/php7.1-mailparse.json
+++ b/php7.1-mailparse.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/mailparse",
-  "version": "3.0.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x64.zip",
-      "hash": "143266d822863006e807ca4602f95b8cbb39d63e0fe80c30a180c62f0cf69f32"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x86.zip",
-      "hash": "011ec947bd9d8597f9e76084e7dca206f0461c0c1956781387ed34bc440d2988"
-    }
-  },
-  "checkver": "mailparse/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/mailparse",
+    "version": "3.0.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/mailparse/$version/php_mailparse-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/mailparse/$version/php_mailparse-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x64.zip",
+            "hash": "143266d822863006e807ca4602f95b8cbb39d63e0fe80c30a180c62f0cf69f32"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/mailparse/3.0.2/php_mailparse-3.0.2-7.1-ts-vc14-x86.zip",
+            "hash": "011ec947bd9d8597f9e76084e7dca206f0461c0c1956781387ed34bc440d2988"
+        }
+    },
+    "checkver": "mailparse/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/mailparse/$version/php_mailparse-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/mailparse/$version/php_mailparse-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-mongodb.json
+++ b/php7.1-mongodb.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://pecl.php.net/package/mongodb",
-    "version": "1.2.9",
+    "version": "1.2.10",
     "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x64.zip",
-            "hash": "a1e09d8b50b5c026fdc71467c4dfa7b97c2ce9edcd7d19917fd53c1a68064dd5"
+            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.10/php_mongodb-1.2.10-7.1-ts-vc14-x64.zip",
+            "hash": "6cd3e82c266026cf088af1b63950ab869d4c05cec2e031ec9bd84afb6c505ce6"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x86.zip",
-            "hash": "6ad05920c57cba1e41d0f703a609e69d82311c2f82b97c6bb4b07dc3063bf3cb"
+            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.10/php_mongodb-1.2.10-7.1-ts-vc14-x86.zip",
+            "hash": "3c9d16fbbc02f1bb6306ac614862ccd5a2c6e8f0416c179c928f6f7d656da3eb"
         }
     },
     "checkver": "mongodb/([\\d.]+)/windows",

--- a/php7.1-mongodb.json
+++ b/php7.1-mongodb.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/mongodb",
-  "version": "1.2.9",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x64.zip",
-      "hash": "a1e09d8b50b5c026fdc71467c4dfa7b97c2ce9edcd7d19917fd53c1a68064dd5"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x86.zip",
-      "hash": "6ad05920c57cba1e41d0f703a609e69d82311c2f82b97c6bb4b07dc3063bf3cb"
-    }
-  },
-  "checkver": "mongodb/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/mongodb",
+    "version": "1.2.9",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/mongodb/$version/php_mongodb-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/mongodb/$version/php_mongodb-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x64.zip",
+            "hash": "a1e09d8b50b5c026fdc71467c4dfa7b97c2ce9edcd7d19917fd53c1a68064dd5"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/mongodb/1.2.9/php_mongodb-1.2.9-7.1-ts-vc14-x86.zip",
+            "hash": "6ad05920c57cba1e41d0f703a609e69d82311c2f82b97c6bb4b07dc3063bf3cb"
+        }
+    },
+    "checkver": "mongodb/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/mongodb/$version/php_mongodb-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/mongodb/$version/php_mongodb-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-msgpack.json
+++ b/php7.1-msgpack.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/msgpack",
-  "version": "2.0.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/msgpack/2.0.2/php_msgpack-2.0.2-7.1-ts-vc14-x64.zip",
-      "hash": "0c2b28ce4d773d160f4dec6aab6575cbe4cb2851009f9616eb31b762c4b38730"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/msgpack/2.0.2/php_msgpack-2.0.2-7.1-ts-vc14-x86.zip",
-      "hash": "8ca558ce3263a94d4364412cc5a887d0bad9c11b70ea2fab7e39631a58bc61b8"
-    }
-  },
-  "checkver": "msgpack/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/msgpack",
+    "version": "2.0.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/msgpack/$version/php_msgpack-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/msgpack/$version/php_msgpack-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/msgpack/2.0.2/php_msgpack-2.0.2-7.1-ts-vc14-x64.zip",
+            "hash": "0c2b28ce4d773d160f4dec6aab6575cbe4cb2851009f9616eb31b762c4b38730"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/msgpack/2.0.2/php_msgpack-2.0.2-7.1-ts-vc14-x86.zip",
+            "hash": "8ca558ce3263a94d4364412cc5a887d0bad9c11b70ea2fab7e39631a58bc61b8"
+        }
+    },
+    "checkver": "msgpack/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/msgpack/$version/php_msgpack-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/msgpack/$version/php_msgpack-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-oauth.json
+++ b/php7.1-oauth.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/oauth",
-  "version": "2.0.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/oauth/2.0.2/php_oauth-2.0.2-7.1-ts-vc14-x64.zip",
-      "hash": "144b546ddad7bce1d7f9c6b655691db655e7f54b83c81cea05f7744fe675add3"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/oauth/2.0.2/php_oauth-2.0.2-7.1-ts-vc14-x86.zip",
-      "hash": "8064204a645a97f6588a2f81b8590cd9a570dbf968dd1b5fb8a3fca4d1f48de1"
-    }
-  },
-  "checkver": "oauth/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/oauth",
+    "version": "2.0.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/oauth/$version/php_oauth-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/oauth/$version/php_oauth-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/oauth/2.0.2/php_oauth-2.0.2-7.1-ts-vc14-x64.zip",
+            "hash": "144b546ddad7bce1d7f9c6b655691db655e7f54b83c81cea05f7744fe675add3"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/oauth/2.0.2/php_oauth-2.0.2-7.1-ts-vc14-x86.zip",
+            "hash": "8064204a645a97f6588a2f81b8590cd9a570dbf968dd1b5fb8a3fca4d1f48de1"
+        }
+    },
+    "checkver": "oauth/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/oauth/$version/php_oauth-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/oauth/$version/php_oauth-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-pcs.json
+++ b/php7.1-pcs.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/pcs",
-  "version": "1.3.3",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/pcs/1.3.3/php_pcs-1.3.3-7.1-ts-vc14-x64.zip",
-      "hash": "8398b477ceb9b0d39c82c9deca9459e176355ace53ec9d5c0840b09f4447f015"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/pcs/1.3.3/php_pcs-1.3.3-7.1-ts-vc14-x86.zip",
-      "hash": "438a9c25d54d38d7b7cced2c146ba9f7c2529b81e1a0b150dbe02659fe2171dd"
-    }
-  },
-  "checkver": "pcs/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/pcs",
+    "version": "1.3.3",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/pcs/$version/php_pcs-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/pcs/$version/php_pcs-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/pcs/1.3.3/php_pcs-1.3.3-7.1-ts-vc14-x64.zip",
+            "hash": "8398b477ceb9b0d39c82c9deca9459e176355ace53ec9d5c0840b09f4447f015"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/pcs/1.3.3/php_pcs-1.3.3-7.1-ts-vc14-x86.zip",
+            "hash": "438a9c25d54d38d7b7cced2c146ba9f7c2529b81e1a0b150dbe02659fe2171dd"
+        }
+    },
+    "checkver": "pcs/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/pcs/$version/php_pcs-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/pcs/$version/php_pcs-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-propro.json
+++ b/php7.1-propro.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/propro",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/propro/2.0.1/php_propro-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "64f6e25d944c10464d9cf0f85cdb918f17f3eff218c1e1c84fcebc7519e819f6"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/propro/2.0.1/php_propro-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "4050282a7e3088109a24c737a92dd45235da37de3616f78c03e2f6acecdd50da"
-    }
-  },
-  "checkver": "propro/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/propro",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/propro/$version/php_propro-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/propro/$version/php_propro-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/propro/2.0.1/php_propro-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "64f6e25d944c10464d9cf0f85cdb918f17f3eff218c1e1c84fcebc7519e819f6"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/propro/2.0.1/php_propro-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "4050282a7e3088109a24c737a92dd45235da37de3616f78c03e2f6acecdd50da"
+        }
+    },
+    "checkver": "propro/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/propro/$version/php_propro-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/propro/$version/php_propro-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-rdkafka.json
+++ b/php7.1-rdkafka.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/rdkafka",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/2.0.1/php_rdkafka-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "e38b3060a7020c1c9bad018baaf83ad4beec829864e205c994c82368bbf75bd8"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/2.0.1/php_rdkafka-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "b18845819541b2a25b41fc6dcc397e2ae953a6009a1e2b2f2f40f869c3dbca15"
-    }
-  },
-  "checkver": "rdkafka/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/rdkafka",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/$version/php_rdkafka-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/$version/php_rdkafka-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/2.0.1/php_rdkafka-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "e38b3060a7020c1c9bad018baaf83ad4beec829864e205c994c82368bbf75bd8"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/2.0.1/php_rdkafka-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "b18845819541b2a25b41fc6dcc397e2ae953a6009a1e2b2f2f40f869c3dbca15"
+        }
+    },
+    "checkver": "rdkafka/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/$version/php_rdkafka-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/rdkafka/$version/php_rdkafka-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-rrd.json
+++ b/php7.1-rrd.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/rrd",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/rrd/2.0.1/php_rrd-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "451643e60831a48176538079043a834c75918f122757109e68c0299d4fabc05c"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/rrd/2.0.1/php_rrd-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "a469eeaeeef6ad9a24cb4193ca84411c38004abaaa5b3c6f188b8fd33232da60"
-    }
-  },
-  "checkver": "rrd/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/rrd",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/rrd/$version/php_rrd-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/rrd/$version/php_rrd-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/rrd/2.0.1/php_rrd-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "451643e60831a48176538079043a834c75918f122757109e68c0299d4fabc05c"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/rrd/2.0.1/php_rrd-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "a469eeaeeef6ad9a24cb4193ca84411c38004abaaa5b3c6f188b8fd33232da60"
+        }
+    },
+    "checkver": "rrd/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/rrd/$version/php_rrd-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/rrd/$version/php_rrd-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-scrypt.json
+++ b/php7.1-scrypt.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/scrypt",
-  "version": "1.4.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/scrypt/1.4.2/php_scrypt-1.4.2-7.1-ts-vc14-x64.zip",
-      "hash": "18703b1b2ea3b01059f43e218b727e7fa3efb85de6579dd47171b4d95921844a"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/scrypt/1.4.2/php_scrypt-1.4.2-7.1-ts-vc14-x86.zip",
-      "hash": "69996b94fd8284035dc963cbe449454e96a10177764a20bceef99d3b4cd738d3"
-    }
-  },
-  "checkver": "scrypt/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/scrypt",
+    "version": "1.4.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/scrypt/$version/php_scrypt-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/scrypt/$version/php_scrypt-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/scrypt/1.4.2/php_scrypt-1.4.2-7.1-ts-vc14-x64.zip",
+            "hash": "18703b1b2ea3b01059f43e218b727e7fa3efb85de6579dd47171b4d95921844a"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/scrypt/1.4.2/php_scrypt-1.4.2-7.1-ts-vc14-x86.zip",
+            "hash": "69996b94fd8284035dc963cbe449454e96a10177764a20bceef99d3b4cd738d3"
+        }
+    },
+    "checkver": "scrypt/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/scrypt/$version/php_scrypt-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/scrypt/$version/php_scrypt-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-seaslog.json
+++ b/php7.1-seaslog.json
@@ -12,7 +12,7 @@
             "hash": "1952e27fe31307377ba114c30886e358a97a13457ae789c531fa23cb872053f4"
         }
     },
-    "checkver": "seaslog/([\\d.]+)/windows",
+    "checkver": "(?i)seaslog/([\\d.]+)/windows",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/php7.1-seaslog.json
+++ b/php7.1-seaslog.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://pecl.php.net/package/seaslog",
-    "version": "1.6.9",
+    "version": "1.7.5",
     "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x64.zip",
-            "hash": "98ff536b4f8d469e963b4e98923f9887535cd6866e520f415afd3a0fb3a5c5fb"
+            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.7.5/php_seaslog-1.7.5-7.1-ts-vc14-x64.zip",
+            "hash": "299f291828fc784a678b99fc54e90fad6651db02e7af6bffdcba4001de9f99a4"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x86.zip",
-            "hash": "1952e27fe31307377ba114c30886e358a97a13457ae789c531fa23cb872053f4"
+            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.7.5/php_seaslog-1.7.5-7.1-ts-vc14-x86.zip",
+            "hash": "9dcb083b79e5a18a55659e1de402348994dc4d0c6875ccb1cba7395774174f4a"
         }
     },
     "checkver": "(?i)seaslog/([\\d.]+)/windows",

--- a/php7.1-seaslog.json
+++ b/php7.1-seaslog.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/seaslog",
-  "version": "1.6.9",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x64.zip",
-      "hash": "98ff536b4f8d469e963b4e98923f9887535cd6866e520f415afd3a0fb3a5c5fb"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x86.zip",
-      "hash": "1952e27fe31307377ba114c30886e358a97a13457ae789c531fa23cb872053f4"
-    }
-  },
-  "checkver": "seaslog/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/seaslog",
+    "version": "1.6.9",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/seaslog/$version/php_seaslog-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/seaslog/$version/php_seaslog-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x64.zip",
+            "hash": "98ff536b4f8d469e963b4e98923f9887535cd6866e520f415afd3a0fb3a5c5fb"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/seaslog/1.6.9/php_seaslog-1.6.9-7.1-ts-vc14-x86.zip",
+            "hash": "1952e27fe31307377ba114c30886e358a97a13457ae789c531fa23cb872053f4"
+        }
+    },
+    "checkver": "seaslog/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/seaslog/$version/php_seaslog-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/seaslog/$version/php_seaslog-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-solr.json
+++ b/php7.1-solr.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/solr",
-  "version": "2.4.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/solr/2.4.0/php_solr-2.4.0-7.1-ts-vc14-x64.zip",
-      "hash": "be5169f9e4beddecd943c3e8ad74f69b52bf01a03e7639bca50ad661b19e20ec"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/solr/2.4.0/php_solr-2.4.0-7.1-ts-vc14-x86.zip",
-      "hash": "6eda2f911b1410548bd98116912c3c64c6f8c900a4318feaec81fba06c65cd4b"
-    }
-  },
-  "checkver": "solr/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/solr",
+    "version": "2.4.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/solr/$version/php_solr-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/solr/$version/php_solr-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/solr/2.4.0/php_solr-2.4.0-7.1-ts-vc14-x64.zip",
+            "hash": "be5169f9e4beddecd943c3e8ad74f69b52bf01a03e7639bca50ad661b19e20ec"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/solr/2.4.0/php_solr-2.4.0-7.1-ts-vc14-x86.zip",
+            "hash": "6eda2f911b1410548bd98116912c3c64c6f8c900a4318feaec81fba06c65cd4b"
+        }
+    },
+    "checkver": "solr/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/solr/$version/php_solr-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/solr/$version/php_solr-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-stem.json
+++ b/php7.1-stem.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/stem",
-  "version": "1.5.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/stem/1.5.1/php_stem-1.5.1-7.1-ts-vc14-x64.zip",
-      "hash": "04c9f7f90e4d3e4ff09a6e4dd1424771a64db9ab3859749ebccf07325fb9e74b"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/stem/1.5.1/php_stem-1.5.1-7.1-ts-vc14-x86.zip",
-      "hash": "06254363c3f08d4f66b1c55add0acc782249f43fdfe853d21185dd8bf78c6169"
-    }
-  },
-  "checkver": "stem/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/stem",
+    "version": "1.5.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/stem/$version/php_stem-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/stem/$version/php_stem-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/stem/1.5.1/php_stem-1.5.1-7.1-ts-vc14-x64.zip",
+            "hash": "04c9f7f90e4d3e4ff09a6e4dd1424771a64db9ab3859749ebccf07325fb9e74b"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/stem/1.5.1/php_stem-1.5.1-7.1-ts-vc14-x86.zip",
+            "hash": "06254363c3f08d4f66b1c55add0acc782249f43fdfe853d21185dd8bf78c6169"
+        }
+    },
+    "checkver": "stem/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/stem/$version/php_stem-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/stem/$version/php_stem-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-stomp.json
+++ b/php7.1-stomp.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/stomp",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/stomp/2.0.1/php_stomp-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "58ebcccb0680595f630a07899842e563513611cd4ce9a116a9a45f6553086fea"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/stomp/2.0.1/php_stomp-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "46ef076a36d47485b3babc12da8fcf0747cd1c0b5144409fce3657d56b53b6ac"
-    }
-  },
-  "checkver": "stomp/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/stomp",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/stomp/$version/php_stomp-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/stomp/$version/php_stomp-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/stomp/2.0.1/php_stomp-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "58ebcccb0680595f630a07899842e563513611cd4ce9a116a9a45f6553086fea"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/stomp/2.0.1/php_stomp-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "46ef076a36d47485b3babc12da8fcf0747cd1c0b5144409fce3657d56b53b6ac"
+        }
+    },
+    "checkver": "stomp/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/stomp/$version/php_stomp-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/stomp/$version/php_stomp-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-taint.json
+++ b/php7.1-taint.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://pecl.php.net/package/taint",
-    "version": "2.0.2",
+    "version": "2.0.4",
     "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x64.zip",
-            "hash": "48df5126611229e2f9383c0b834b966046f10bb4bf972caea45765d64cd6c683"
+            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.4/php_taint-2.0.4-7.1-ts-vc14-x64.zip",
+            "hash": "d79febbdfa5bab562b0a38563c3117d0c95180919fd59976f5b2b40d86d4ab8e"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x86.zip",
-            "hash": "cdf9838426090ff1d6114086bfb885ca95a0ff4cad12edbf11a81d6447c42352"
+            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.4/php_taint-2.0.4-7.1-ts-vc14-x86.zip",
+            "hash": "928baa8fb675b9ea7c61f119497195c1d984c9e18a6cab40295ad56de39d83e2"
         }
     },
     "checkver": "taint/([\\d.]+)/windows",

--- a/php7.1-taint.json
+++ b/php7.1-taint.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/taint",
-  "version": "2.0.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x64.zip",
-      "hash": "48df5126611229e2f9383c0b834b966046f10bb4bf972caea45765d64cd6c683"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x86.zip",
-      "hash": "cdf9838426090ff1d6114086bfb885ca95a0ff4cad12edbf11a81d6447c42352"
-    }
-  },
-  "checkver": "taint/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/taint",
+    "version": "2.0.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/taint/$version/php_taint-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/taint/$version/php_taint-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x64.zip",
+            "hash": "48df5126611229e2f9383c0b834b966046f10bb4bf972caea45765d64cd6c683"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/taint/2.0.2/php_taint-2.0.2-7.1-ts-vc14-x86.zip",
+            "hash": "cdf9838426090ff1d6114086bfb885ca95a0ff4cad12edbf11a81d6447c42352"
+        }
+    },
+    "checkver": "taint/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/taint/$version/php_taint-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/taint/$version/php_taint-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-timezonedb.json
+++ b/php7.1-timezonedb.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/timezonedb",
-  "version": "2017.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/2017.2/php_timezonedb-2017.2-7.1-ts-vc14-x64.zip",
-      "hash": "81559c1e8316026521063a9cd4c2c3e1c3db7687dcb90d770742db4d8e14810b"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/2017.2/php_timezonedb-2017.2-7.1-ts-vc14-x86.zip",
-      "hash": "9ad8e08cd1da68d68a4449c84890fb8c1f1182a85f04fb0992edfd28a348cf05"
-    }
-  },
-  "checkver": "timezonedb/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/timezonedb",
+    "version": "2017.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/$version/php_timezonedb-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/$version/php_timezonedb-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/2017.2/php_timezonedb-2017.2-7.1-ts-vc14-x64.zip",
+            "hash": "81559c1e8316026521063a9cd4c2c3e1c3db7687dcb90d770742db4d8e14810b"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/2017.2/php_timezonedb-2017.2-7.1-ts-vc14-x86.zip",
+            "hash": "9ad8e08cd1da68d68a4449c84890fb8c1f1182a85f04fb0992edfd28a348cf05"
+        }
+    },
+    "checkver": "timezonedb/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/$version/php_timezonedb-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/timezonedb/$version/php_timezonedb-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-trader.json
+++ b/php7.1-trader.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/trader",
-  "version": "0.4.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/trader/0.4.0/php_trader-0.4.0-7.1-ts-vc14-x64.zip",
-      "hash": "8137fd2ec97d5d009aea19d38ad9153b5cc566023e854e2e709586c3f6a08ac4"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/trader/0.4.0/php_trader-0.4.0-7.1-ts-vc14-x86.zip",
-      "hash": "e097b355999e9bfa611c5ea70702b5d3f5251de0fa7a5dba9b99513412639ee3"
-    }
-  },
-  "checkver": "trader/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/trader",
+    "version": "0.4.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/trader/$version/php_trader-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/trader/$version/php_trader-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/trader/0.4.0/php_trader-0.4.0-7.1-ts-vc14-x64.zip",
+            "hash": "8137fd2ec97d5d009aea19d38ad9153b5cc566023e854e2e709586c3f6a08ac4"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/trader/0.4.0/php_trader-0.4.0-7.1-ts-vc14-x86.zip",
+            "hash": "e097b355999e9bfa611c5ea70702b5d3f5251de0fa7a5dba9b99513412639ee3"
+        }
+    },
+    "checkver": "trader/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/trader/$version/php_trader-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/trader/$version/php_trader-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-translit.json
+++ b/php7.1-translit.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/translit",
-  "version": "0.6.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/translit/0.6.2/php_translit-0.6.2-7.1-ts-vc14-x64.zip",
-      "hash": "f28ff18db60613bdd7179e4d21bb1e39a454bdfb29f4c8a3372d232cccb9e369"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/translit/0.6.2/php_translit-0.6.2-7.1-ts-vc14-x86.zip",
-      "hash": "a14bb58c7ca0b970d61f9379d3dc36f40062a3fee77636e94c380b2271899cf1"
-    }
-  },
-  "checkver": "translit/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/translit",
+    "version": "0.6.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/translit/$version/php_translit-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/translit/$version/php_translit-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/translit/0.6.2/php_translit-0.6.2-7.1-ts-vc14-x64.zip",
+            "hash": "f28ff18db60613bdd7179e4d21bb1e39a454bdfb29f4c8a3372d232cccb9e369"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/translit/0.6.2/php_translit-0.6.2-7.1-ts-vc14-x86.zip",
+            "hash": "a14bb58c7ca0b970d61f9379d3dc36f40062a3fee77636e94c380b2271899cf1"
+        }
+    },
+    "checkver": "translit/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/translit/$version/php_translit-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/translit/$version/php_translit-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-ui.json
+++ b/php7.1-ui.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/ui",
-  "version": "2.0.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/ui/2.0.0/php_ui-2.0.0-7.1-ts-vc14-x64.zip",
-      "hash": "7d1c51f956f088f4f653116cb28bc1e66fc674c76a0f0765397b4bbb8f18ad92"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/ui/2.0.0/php_ui-2.0.0-7.1-ts-vc14-x86.zip",
-      "hash": "2f8c1b004178d4d3eae084c4d4a7de09fb6ef89f311170c2789241d0959708c1"
-    }
-  },
-  "checkver": "ui/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/ui",
+    "version": "2.0.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/ui/$version/php_ui-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/ui/$version/php_ui-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/ui/2.0.0/php_ui-2.0.0-7.1-ts-vc14-x64.zip",
+            "hash": "7d1c51f956f088f4f653116cb28bc1e66fc674c76a0f0765397b4bbb8f18ad92"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/ui/2.0.0/php_ui-2.0.0-7.1-ts-vc14-x86.zip",
+            "hash": "2f8c1b004178d4d3eae084c4d4a7de09fb6ef89f311170c2789241d0959708c1"
+        }
+    },
+    "checkver": "ui/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/ui/$version/php_ui-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/ui/$version/php_ui-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-varnish.json
+++ b/php7.1-varnish.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/varnish",
-  "version": "1.2.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/varnish/1.2.2/php_varnish-1.2.2-7.1-ts-vc14-x64.zip",
-      "hash": "cca1effaa9506aaacdde2c77cc6b9bcf974fb100bcb466f6acae8ff7a9da464e"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/varnish/1.2.2/php_varnish-1.2.2-7.1-ts-vc14-x86.zip",
-      "hash": "a72fa709d431b5b12096e3216d9c9b6cabd60eea3375bf5607e16fe2ca7e19d2"
-    }
-  },
-  "checkver": "varnish/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/varnish",
+    "version": "1.2.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/varnish/$version/php_varnish-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/varnish/$version/php_varnish-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/varnish/1.2.2/php_varnish-1.2.2-7.1-ts-vc14-x64.zip",
+            "hash": "cca1effaa9506aaacdde2c77cc6b9bcf974fb100bcb466f6acae8ff7a9da464e"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/varnish/1.2.2/php_varnish-1.2.2-7.1-ts-vc14-x86.zip",
+            "hash": "a72fa709d431b5b12096e3216d9c9b6cabd60eea3375bf5607e16fe2ca7e19d2"
+        }
+    },
+    "checkver": "varnish/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/varnish/$version/php_varnish-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/varnish/$version/php_varnish-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-vld.json
+++ b/php7.1-vld.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/vld",
-  "version": "0.14.0",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/vld/0.14.0/php_vld-0.14.0-7.1-ts-vc14-x64.zip",
-      "hash": "94e328b10da07f5c9e6bd743f4bdda7c96b7edbf5ded5bf33588eaecd5f91607"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/vld/0.14.0/php_vld-0.14.0-7.1-ts-vc14-x86.zip",
-      "hash": "1d359206fd2d928bd12afe7e96e87176d8e527f8ba881e3497470ea6911d5c42"
-    }
-  },
-  "checkver": "vld/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/vld",
+    "version": "0.14.0",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/vld/$version/php_vld-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/vld/$version/php_vld-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/vld/0.14.0/php_vld-0.14.0-7.1-ts-vc14-x64.zip",
+            "hash": "94e328b10da07f5c9e6bd743f4bdda7c96b7edbf5ded5bf33588eaecd5f91607"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/vld/0.14.0/php_vld-0.14.0-7.1-ts-vc14-x86.zip",
+            "hash": "1d359206fd2d928bd12afe7e96e87176d8e527f8ba881e3497470ea6911d5c42"
+        }
+    },
+    "checkver": "vld/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/vld/$version/php_vld-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/vld/$version/php_vld-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-weakref.json
+++ b/php7.1-weakref.json
@@ -12,7 +12,7 @@
             "hash": "e33a3320c17d033526cec49db673803b5ccf6597d4241b31c3a93d2ae223191d"
         }
     },
-    "checkver": "weakref/([\\d.]+)/windows",
+    "checkver": "(?i)weakref/([\\d.]+)/windows",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/php7.1-weakref.json
+++ b/php7.1-weakref.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/weakref",
-  "version": "0.3.3",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/weakref/0.3.3/php_weakref-0.3.3-7.1-ts-vc14-x64.zip",
-      "hash": "04f94c163793e8db798d186eed70ad01a14f9d8f57bf00bc0301c33386e3ffa9"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/weakref/0.3.3/php_weakref-0.3.3-7.1-ts-vc14-x86.zip",
-      "hash": "e33a3320c17d033526cec49db673803b5ccf6597d4241b31c3a93d2ae223191d"
-    }
-  },
-  "checkver": "weakref/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/weakref",
+    "version": "0.3.3",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/weakref/$version/php_weakref-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/weakref/$version/php_weakref-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/weakref/0.3.3/php_weakref-0.3.3-7.1-ts-vc14-x64.zip",
+            "hash": "04f94c163793e8db798d186eed70ad01a14f9d8f57bf00bc0301c33386e3ffa9"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/weakref/0.3.3/php_weakref-0.3.3-7.1-ts-vc14-x86.zip",
+            "hash": "e33a3320c17d033526cec49db673803b5ccf6597d4241b31c3a93d2ae223191d"
+        }
+    },
+    "checkver": "weakref/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/weakref/$version/php_weakref-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/weakref/$version/php_weakref-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-win32service.json
+++ b/php7.1-win32service.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/win32service",
-  "version": "0.2.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/win32service/0.2.1/php_win32service-0.2.1-7.1-ts-vc14-x64.zip",
-      "hash": "a26dd22b55b3a053c6a121dad2fb05b5fbcb84ae1eae72ec54ec932014569b09"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/win32service/0.2.1/php_win32service-0.2.1-7.1-ts-vc14-x86.zip",
-      "hash": "448312983f6aed79b33f9e24251b02299c93f5535e55d591ade7e8cfe16094c6"
-    }
-  },
-  "checkver": "win32service/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/win32service",
+    "version": "0.2.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/win32service/$version/php_win32service-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/win32service/$version/php_win32service-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/win32service/0.2.1/php_win32service-0.2.1-7.1-ts-vc14-x64.zip",
+            "hash": "a26dd22b55b3a053c6a121dad2fb05b5fbcb84ae1eae72ec54ec932014569b09"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/win32service/0.2.1/php_win32service-0.2.1-7.1-ts-vc14-x86.zip",
+            "hash": "448312983f6aed79b33f9e24251b02299c93f5535e55d591ade7e8cfe16094c6"
+        }
+    },
+    "checkver": "win32service/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/win32service/$version/php_win32service-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/win32service/$version/php_win32service-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-xdiff.json
+++ b/php7.1-xdiff.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/xdiff",
-  "version": "2.0.1",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xdiff/2.0.1/php_xdiff-2.0.1-7.1-ts-vc14-x64.zip",
-      "hash": "468d894e868d4485b2b41c705006afd7c94fb573f7f0aa23bc6a66d4a2a62c3a"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xdiff/2.0.1/php_xdiff-2.0.1-7.1-ts-vc14-x86.zip",
-      "hash": "e8027df6abecd48d7f625c13b37d54ab82e6de0ac0fce5dde729314362afed00"
-    }
-  },
-  "checkver": "xdiff/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/xdiff",
+    "version": "2.0.1",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xdiff/$version/php_xdiff-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xdiff/$version/php_xdiff-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xdiff/2.0.1/php_xdiff-2.0.1-7.1-ts-vc14-x64.zip",
+            "hash": "468d894e868d4485b2b41c705006afd7c94fb573f7f0aa23bc6a66d4a2a62c3a"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xdiff/2.0.1/php_xdiff-2.0.1-7.1-ts-vc14-x86.zip",
+            "hash": "e8027df6abecd48d7f625c13b37d54ab82e6de0ac0fce5dde729314362afed00"
+        }
+    },
+    "checkver": "xdiff/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xdiff/$version/php_xdiff-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xdiff/$version/php_xdiff-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-xmldiff.json
+++ b/php7.1-xmldiff.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/xmldiff",
-  "version": "1.1.2",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x64.zip",
-      "hash": "655febe677030e74bec49769fc87316cc094ac85305d0e6370479d7904bfdffb"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x86.zip",
-      "hash": "0e771f2ab3288ae4f10567b31252cc10f95f04326bbb0069f6c639d70d06ad7d"
-    }
-  },
-  "checkver": "xmldiff/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/xmldiff",
+    "version": "1.1.2",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/$version/php_xmldiff-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/$version/php_xmldiff-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x64.zip",
+            "hash": "655febe677030e74bec49769fc87316cc094ac85305d0e6370479d7904bfdffb"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x86.zip",
+            "hash": "0e771f2ab3288ae4f10567b31252cc10f95f04326bbb0069f6c639d70d06ad7d"
+        }
+    },
+    "checkver": "xmldiff/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/$version/php_xmldiff-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/$version/php_xmldiff-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-xmldiff.json
+++ b/php7.1-xmldiff.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x64.zip",
-            "hash": "655febe677030e74bec49769fc87316cc094ac85305d0e6370479d7904bfdffb"
+            "hash": "167a421d63737237a0a524213c51460bb8dcc59973a936cb22549e7eb7631e88"
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/pecl/releases/xmldiff/1.1.2/php_xmldiff-1.1.2-7.1-ts-vc14-x86.zip",
-            "hash": "0e771f2ab3288ae4f10567b31252cc10f95f04326bbb0069f6c639d70d06ad7d"
+            "hash": "70ed9320aaa359f216a5b9bcc7e962ee3d1f50c5a80800d9d27e050bc7147cbf"
         }
     },
     "checkver": "xmldiff/([\\d.]+)/windows",

--- a/php7.1-xxtea.json
+++ b/php7.1-xxtea.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/xxtea",
-  "version": "1.0.11",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xxtea/1.0.11/php_xxtea-1.0.11-7.1-ts-vc14-x64.zip",
-      "hash": "f926f23140fb9578fcec09a4f091c349611744250f604ab1179345a47491f687"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/xxtea/1.0.11/php_xxtea-1.0.11-7.1-ts-vc14-x86.zip",
-      "hash": "a5e45ae48ccc68c5a9b77925bd5ec0158aadf45a12dd4fe747d80c70a439e684"
-    }
-  },
-  "checkver": "xxtea/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/xxtea",
+    "version": "1.0.11",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xxtea/$version/php_xxtea-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/xxtea/$version/php_xxtea-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xxtea/1.0.11/php_xxtea-1.0.11-7.1-ts-vc14-x64.zip",
+            "hash": "f926f23140fb9578fcec09a4f091c349611744250f604ab1179345a47491f687"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/xxtea/1.0.11/php_xxtea-1.0.11-7.1-ts-vc14-x86.zip",
+            "hash": "a5e45ae48ccc68c5a9b77925bd5ec0158aadf45a12dd4fe747d80c70a439e684"
+        }
+    },
+    "checkver": "xxtea/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xxtea/$version/php_xxtea-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/xxtea/$version/php_xxtea-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-zip.json
+++ b/php7.1-zip.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/zip",
-  "version": "1.13.5",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/zip/1.13.5/php_zip-1.13.5-7.1-ts-vc14-x64.zip",
-      "hash": "443cfbd982af5c4b79485ef83f5cd1c6cd04ed1fe80c62d83fa82a3aa30c8ff1"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/zip/1.13.5/php_zip-1.13.5-7.1-ts-vc14-x86.zip",
-      "hash": "baad15934868e3e25d61e7d7ee02ab31013b510a6876287468385f67955340ff"
-    }
-  },
-  "checkver": "zip/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/zip",
+    "version": "1.13.5",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/zip/$version/php_zip-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/zip/$version/php_zip-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/zip/1.13.5/php_zip-1.13.5-7.1-ts-vc14-x64.zip",
+            "hash": "443cfbd982af5c4b79485ef83f5cd1c6cd04ed1fe80c62d83fa82a3aa30c8ff1"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/zip/1.13.5/php_zip-1.13.5-7.1-ts-vc14-x86.zip",
+            "hash": "baad15934868e3e25d61e7d7ee02ab31013b510a6876287468385f67955340ff"
+        }
+    },
+    "checkver": "zip/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/zip/$version/php_zip-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/zip/$version/php_zip-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }

--- a/php7.1-zmq.json
+++ b/php7.1-zmq.json
@@ -1,30 +1,30 @@
 {
-  "homepage": "https://pecl.php.net/package/zmq",
-  "version": "1.1.3",
-  "license": "http://www.php.net/license/3_01.txt",
-  "architecture": {
-    "64bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/zmq/1.1.3/php_zmq-1.1.3-7.1-ts-vc14-x64.zip",
-      "hash": "ed73ff2378b96d4df5c3535438f4114b623cc5976b29541b993b005f81437c3f"
-    },
-    "32bit": {
-      "url": "http://windows.php.net/downloads/pecl/releases/zmq/1.1.3/php_zmq-1.1.3-7.1-ts-vc14-x86.zip",
-      "hash": "228f8b9ff6184231f9ef2d24d15e44bb8d25829031280a662f26e62da71dc228"
-    }
-  },
-  "checkver": "zmq/([\\d.]+)/windows",
-  "autoupdate": {
+    "homepage": "https://pecl.php.net/package/zmq",
+    "version": "1.1.3",
+    "license": "http://www.php.net/license/3_01.txt",
     "architecture": {
-      "64bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/zmq/$version/php_zmq-$version-7.1-ts-vc14-x64.zip"
-      },
-      "32bit": {
-        "url": "http://windows.php.net/downloads/pecl/releases/zmq/$version/php_zmq-$version-7.1-ts-vc14-x86.zip"
-      }
+        "64bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/zmq/1.1.3/php_zmq-1.1.3-7.1-ts-vc14-x64.zip",
+            "hash": "ed73ff2378b96d4df5c3535438f4114b623cc5976b29541b993b005f81437c3f"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/pecl/releases/zmq/1.1.3/php_zmq-1.1.3-7.1-ts-vc14-x86.zip",
+            "hash": "228f8b9ff6184231f9ef2d24d15e44bb8d25829031280a662f26e62da71dc228"
+        }
+    },
+    "checkver": "zmq/([\\d.]+)/windows",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/zmq/$version/php_zmq-$version-7.1-ts-vc14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/pecl/releases/zmq/$version/php_zmq-$version-7.1-ts-vc14-x86.zip"
+            }
+        }
+    },
+    "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
+    "uninstaller": {
+        "file": "uninstall.ps1"
     }
-  },
-  "post_install": "iex(gc $bucketsdir\\$bucket\\bin\\postinstall.ps1 -Raw)",
-  "uninstaller": {
-    "file": "uninstall.ps1"
-  }
 }


### PR DESCRIPTION
* Reformated all JSON files so later autoupdates don't mess with the formating
* Regex fixes
* Update couchebase to 2.4.0
* Update mongodb to 1.2.10
* Update seaslog to 1.7.5
* Update taint to 2.0.4
* Fix mailparse hash
* Fix xmldiff hash
